### PR TITLE
feat(one-chart): add support for multiple PVCs

### DIFF
--- a/charts/one-chart/Chart.yaml
+++ b/charts/one-chart/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/one-chart/README.md
+++ b/charts/one-chart/README.md
@@ -1,6 +1,6 @@
 # one-chart
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 One chart to rule them all. One chart to pack them. One chart to bring them all and in the YAMLness bind them.
 
@@ -17,9 +17,9 @@ One chart to rule them all. One chart to pack them. One chart to bring them all 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for pod scheduling |
-| cloudflared | object | `{"enabled":false,"image":{"repository":"cloudflare/cloudflared","tag":"2025.8.0"},"onepassword":{"item":"","vault":"Homelab"},"podAnnotations":{},"podLabels":{},"prometheus":{"enabled":false,"interval":"30s","path":"/metrics","port":2000,"scrapeTimeout":"10s"},"replicaCount":2,"strategy":{"type":"Recreate"},"tunnel":{"localHostname":"","name":"","publicHostname":""}}` | Cloudflared settings |
+| cloudflared | object | `{"enabled":false,"image":{"repository":"cloudflare/cloudflared","tag":"2025.11.1"},"onepassword":{"item":"","vault":"Homelab"},"podAnnotations":{},"podLabels":{},"prometheus":{"enabled":false,"interval":"30s","path":"/metrics","port":2000,"scrapeTimeout":"10s"},"replicaCount":2,"strategy":{"type":"Recreate"},"tunnel":{"localHostname":"","name":"","publicHostname":""}}` | Cloudflared settings |
 | cloudflared.enabled | bool | `false` | Enable Cloudflared deployment |
-| cloudflared.image | object | `{"repository":"cloudflare/cloudflared","tag":"2025.8.0"}` | Cloudflared image repository |
+| cloudflared.image | object | `{"repository":"cloudflare/cloudflared","tag":"2025.11.1"}` | Cloudflared image repository |
 | cloudflared.onepassword | object | `{"item":"","vault":"Homelab"}` | 1Password integration settings for Cloudflared credentials |
 | cloudflared.onepassword.item | string | `""` | The name of the item within the vault containing Cloudflared credentials |
 | cloudflared.onepassword.vault | string | `"Homelab"` | The name of the 1Password vault where Cloudflared credentials are stored |
@@ -64,6 +64,7 @@ One chart to rule them all. One chart to pack them. One chart to bring them all 
 | persistentVolume.mountPath | string | `"/data"` | Mount path for the persistent volume. Defaults to /data |
 | persistentVolume.size | string | `"1Gi"` | Size of the persistent volume. Defaults to 1Gi |
 | persistentVolume.storageClass | string | `"longhorn-default-sc"` | Storage class for PVC. Defaults to "longhorn-default-sc" |
+| persistentVolumes | list | `[]` | List of persistent volumes for the deployment. Takes precedence over `persistentVolume` (single volume) for backward compatibility. |
 | podAnnotations | object | `{}` | Annotations for the pod |
 | podLabels | object | `{}` | Additional labels for the pod |
 | podSecurityContext | object | `{}` | Pod-level security context |

--- a/charts/one-chart/templates/deployment.yaml
+++ b/charts/one-chart/templates/deployment.yaml
@@ -75,22 +75,25 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.volumeMounts }}
+          {{- if or .Values.volumeMounts .Values.persistentVolumes (and .Values.persistentVolume.enabled (not .Values.persistentVolumes)) }}
           volumeMounts:
+            {{- if .Values.volumeMounts }}
             {{- toYaml .Values.volumeMounts | nindent 12 }}
-            {{- if .Values.persistentVolume.enabled }}
+            {{- end }}
+            {{- if .Values.persistentVolumes }}
+            {{- range .Values.persistentVolumes }}
+            - name: {{ include "one-chart.fullname" $ }}-{{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- else if .Values.persistentVolume.enabled }}
             - name: {{ include "one-chart.fullname" . }}
               mountPath: {{ .Values.persistentVolume.mountPath | default "/data" }}
             {{- end }}
-          {{- else if .Values.persistentVolume.enabled }}
-          volumeMounts:
-            - name: {{ include "one-chart.fullname" . }}
-              mountPath: {{ .Values.persistentVolume.mountPath | default "/data" }}
           {{- end }}
           {{- with .Values.environmentVariables }}
           {{- if .container.enabled }}
           env:
-            {{- toYaml .container.variables | nindent 10 }}
+            {{- toYaml .container.variables | nindent 12 }}
           {{- end }}
           {{- if or .fromConfigMap.enabled .fromSecret.enabled }}
           envFrom:
@@ -108,19 +111,22 @@ spec:
             {{- end }}
           {{- end }}
           {{- end }}
-      {{- if .Values.volumes }}
+      {{- if or .Values.volumes .Values.persistentVolumes (and .Values.persistentVolume.enabled (not .Values.persistentVolumes)) }}
       volumes:
+        {{- if .Values.volumes }}
         {{- toYaml .Values.volumes | nindent 8 }}
-        {{- if .Values.persistentVolume.enabled }}
+        {{- end }}
+        {{- if .Values.persistentVolumes }}
+        {{- range .Values.persistentVolumes }}
+        - name: {{ include "one-chart.fullname" $ }}-{{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ include "one-chart.fullname" $ }}-{{ .name }}
+        {{- end }}
+        {{- else if .Values.persistentVolume.enabled }}
         - name: {{ include "one-chart.fullname" . }}
           persistentVolumeClaim:
             claimName: {{ include "one-chart.fullname" . }}
         {{- end }}
-      {{- else if .Values.persistentVolume.enabled }}
-      volumes:
-        - name: {{ include "one-chart.fullname" . }}
-          persistentVolumeClaim:
-            claimName: {{ include "one-chart.fullname" . }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/one-chart/templates/pvc.yaml
+++ b/charts/one-chart/templates/pvc.yaml
@@ -1,4 +1,23 @@
-{{- if .Values.persistentVolume.enabled }}
+{{- if .Values.persistentVolumes }}
+{{- range .Values.persistentVolumes }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "one-chart.fullname" $ }}-{{ .name }}
+  labels: 
+    {{- include "one-chart.labels" $ | nindent 4 }}
+spec:
+  accessModes:
+    {{- range .accessModes | default (list "ReadWriteOnce") }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .size | default "1Gi" }}
+  storageClassName: {{ .storageClass }}
+{{- end }}
+{{- else if .Values.persistentVolume.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/one-chart/tests/deployment_test.yaml
+++ b/charts/one-chart/tests/deployment_test.yaml
@@ -549,3 +549,147 @@ tests:
           path: spec.template.metadata.annotations["prometheus.io/interval"]
       - notExists:
           path: spec.template.metadata.annotations["prometheus.io/scrape_timeout"]
+
+  - it: should render multiple PVC volumes and volumeMounts when persistentVolumes list is provided
+    set:
+      image.tag: "1.16.0"
+      persistentVolumes:
+        - name: data
+          storageClass: longhorn-data
+          size: 20Gi
+          mountPath: /data
+          accessModes:
+            - ReadWriteOnce
+        - name: backup
+          storageClass: longhorn-backup
+          size: 30Gi
+          mountPath: /backup
+          accessModes:
+            - ReadWriteMany
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: test-release-one-chart-data
+            persistentVolumeClaim:
+              claimName: test-release-one-chart-data
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: test-release-one-chart-backup
+            persistentVolumeClaim:
+              claimName: test-release-one-chart-backup
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-release-one-chart-data
+            mountPath: /data
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-release-one-chart-backup
+            mountPath: /backup
+
+  - it: should prefer persistentVolumes over persistentVolume when both are set
+    set:
+      image.tag: "1.16.0"
+      persistentVolume:
+        enabled: true
+        storageClass: longhorn-default-sc
+        size: 5Gi
+        mountPath: /data
+      persistentVolumes:
+        - name: main
+          storageClass: other-sc
+          size: 20Gi
+          mountPath: /main
+          accessModes:
+            - ReadWriteOnce
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: test-release-one-chart-main
+            persistentVolumeClaim:
+              claimName: test-release-one-chart-main
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-release-one-chart-main
+            mountPath: /main
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: test-release-one-chart
+            persistentVolumeClaim:
+              claimName: test-release-one-chart
+
+  - it: should render both custom volumes and multiple PVC volumes when persistentVolumes is set
+    set:
+      image.tag: "1.16.0"
+      volumes:
+        - name: custom-volume
+          emptyDir: {}
+      persistentVolumes:
+        - name: data
+          storageClass: longhorn-data
+          size: 20Gi
+          mountPath: /data
+          accessModes:
+            - ReadWriteOnce
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: custom-volume
+            emptyDir: {}
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: test-release-one-chart-data
+            persistentVolumeClaim:
+              claimName: test-release-one-chart-data
+
+  - it: should render both custom volumeMounts and multiple PVC volumeMounts when persistentVolumes is set
+    set:
+      image.tag: "1.16.0"
+      volumeMounts:
+        - name: custom-volume
+          mountPath: /custom
+      persistentVolumes:
+        - name: data
+          storageClass: longhorn-data
+          size: 20Gi
+          mountPath: /data
+          accessModes:
+            - ReadWriteOnce
+        - name: backup
+          storageClass: longhorn-backup
+          size: 30Gi
+          mountPath: /backup
+          accessModes:
+            - ReadWriteMany
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: custom-volume
+            mountPath: /custom
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-release-one-chart-data
+            mountPath: /data
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: test-release-one-chart-backup
+            mountPath: /backup

--- a/charts/one-chart/tests/pvc_test.yaml
+++ b/charts/one-chart/tests/pvc_test.yaml
@@ -59,3 +59,198 @@ tests:
       - equal:
           path: spec.resources.requests.storage
           value: 10Gi
+
+  - it: should render multiple PersistentVolumeClaims when persistentVolumes list is provided
+    set:
+      persistentVolumes:
+        - name: data
+          storageClass: longhorn-data
+          size: 20Gi
+          mountPath: /data
+          accessModes:
+            - ReadWriteOnce
+        - name: backup
+          storageClass: longhorn-backup
+          size: 30Gi
+          mountPath: /backup
+          accessModes:
+            - ReadWriteMany
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+
+  - it: should render first PVC with correct name, storage, storageClassName, and accessModes for data volume
+    documentIndex: 0
+    set:
+      persistentVolumes:
+        - name: data
+          storageClass: longhorn-data
+          size: 20Gi
+          mountPath: /data
+          accessModes:
+            - ReadWriteOnce
+        - name: backup
+          storageClass: longhorn-backup
+          size: 30Gi
+          mountPath: /backup
+          accessModes:
+            - ReadWriteMany
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: pvc-release-one-chart-data
+      - equal:
+          path: spec.storageClassName
+          value: longhorn-data
+      - equal:
+          path: spec.resources.requests.storage
+          value: 20Gi
+      - equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteOnce
+
+  - it: should render second PVC with correct name, storage, storageClassName, and accessModes for backup volume
+    documentIndex: 1
+    set:
+      persistentVolumes:
+        - name: data
+          storageClass: longhorn-data
+          size: 20Gi
+          mountPath: /data
+          accessModes:
+            - ReadWriteOnce
+        - name: backup
+          storageClass: longhorn-backup
+          size: 30Gi
+          mountPath: /backup
+          accessModes:
+            - ReadWriteMany
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: pvc-release-one-chart-backup
+      - equal:
+          path: spec.storageClassName
+          value: longhorn-backup
+      - equal:
+          path: spec.resources.requests.storage
+          value: 30Gi
+      - equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteMany
+
+  - it: should set correct storage and storageClassName for first PVC (data) in multi-volume configuration
+    documentIndex: 0
+    set:
+      persistentVolumes:
+        - name: data
+          storageClass: fast-ssd
+          size: 50Gi
+          mountPath: /data
+          accessModes:
+            - ReadWriteOnce
+        - name: cache
+          storageClass: fast-nvme
+          size: 100Gi
+          mountPath: /cache
+          accessModes:
+            - ReadWriteOnce
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: pvc-release-one-chart-data
+      - equal:
+          path: spec.storageClassName
+          value: fast-ssd
+      - equal:
+          path: spec.resources.requests.storage
+          value: 50Gi
+
+  - it: should set correct storage and storageClassName for second PVC (cache) in multi-volume configuration
+    documentIndex: 1
+    set:
+      persistentVolumes:
+        - name: data
+          storageClass: fast-ssd
+          size: 50Gi
+          mountPath: /data
+          accessModes:
+            - ReadWriteOnce
+        - name: cache
+          storageClass: fast-nvme
+          size: 100Gi
+          mountPath: /cache
+          accessModes:
+            - ReadWriteOnce
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: pvc-release-one-chart-cache
+      - equal:
+          path: spec.storageClassName
+          value: fast-nvme
+      - equal:
+          path: spec.resources.requests.storage
+          value: 100Gi
+
+  - it: should use default accessModes if not specified in persistentVolumes
+    set:
+      persistentVolumes:
+        - name: data
+          storageClass: longhorn-default-sc
+          size: 10Gi
+          mountPath: /data
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: pvc-release-one-chart-data
+      - equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteOnce
+
+  - it: should prefer persistentVolumes over persistentVolume when both are set (use main from persistentVolumes)
+    set:
+      persistentVolume:
+        enabled: true
+        storageClass: longhorn-default-sc
+        size: 5Gi
+        mountPath: /data
+      persistentVolumes:
+        - name: main
+          storageClass: other-sc
+          size: 20Gi
+          mountPath: /main
+          accessModes:
+            - ReadWriteOnce
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: pvc-release-one-chart-main
+      - equal:
+          path: spec.storageClassName
+          value: other-sc
+      - equal:
+          path: spec.resources.requests.storage
+          value: 20Gi
+      - equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteOnce
+      - notEqual:
+          path: spec.storageClassName
+          value: longhorn-default-sc

--- a/charts/one-chart/values.yaml
+++ b/charts/one-chart/values.yaml
@@ -212,6 +212,21 @@ persistentVolume:
   # -- Mount path for the persistent volume. Defaults to /data
   mountPath: /data
 
+# -- List of persistent volumes for the deployment. Takes precedence over `persistentVolume` (single volume) for backward compatibility.
+persistentVolumes: []
+# - name: data
+#   storageClass: "longhorn-default-sc"
+#   accessModes:
+#     - ReadWriteOnce
+#   size: 10Gi
+#   mountPath: /data
+# - name: backup
+#   storageClass: "longhorn-backup-sc"
+#   accessModes:
+#     - ReadWriteOnce
+#   size: 20Gi
+#   mountPath: /backup
+
 # -- 1Password integration settings
 onepassword:
   # -- Enable creating a OnePasswordItem to generate a Kubernetes Secret.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configuring multiple persistent volumes for more flexible storage management (backward-compatible fallback to single-volume).

* **Updates**
  * Default cloudflared image tag updated to 2025.11.1.
  * Chart version bumped to 0.11.0.
  * Documentation enhanced with new multi-volume configuration examples and guidance.

* **Tests**
  * Expanded test coverage for multi-volume setups, precedence, and compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->